### PR TITLE
Replace headers instead of appending duplicates in order to match git-lfs behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ See https://github.com/bozaro/git-lfs-java/blob/master/gitlfs-server/src/test/ja
 
 Version 0.13.0 (Unreleased)
 
+ * Fix compatibility with Gitea LFS
+
 Version 0.12.0
 
  * Update dependencies

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/Client.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/Client.java
@@ -322,7 +322,7 @@ public class Client {
   protected void addHeaders(@NotNull HttpUriRequest req, @Nullable Link link) {
     if (link != null) {
       for (Map.Entry<String, String> entry : link.getHeader().entrySet()) {
-        req.addHeader(entry.getKey(), entry.getValue());
+        req.setHeader(entry.getKey(), entry.getValue());
       }
     }
   }


### PR DESCRIPTION
See https://github.com/go-gitea/gitea/pull/6958

While I believe this is supposed to be fixed on Gitea side, we can make changes
in order to become compatible with older Gitea releases.