### PR TITLE
Add missing 'name' and 'description' fields to Maven POM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,9 @@ subprojects {
                 artifact(javadocJar)
 
                 pom {
+                    name.set(project.name)
+                    description.set(project.description)
+
                     url.set("https://github.com/bozaro/git-lfs-java")
 
                     scm {


### PR DESCRIPTION
Broken by 984cef5cf1791d956d5f2f6331cfbde854320fd8