### PR TITLE
Move snapshot/release logic into build.gradle.kts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ jobs:
       install: true
       script:
         - openssl aes-256-cbc -K $encrypted_8e5c960335c9_key -iv $encrypted_8e5c960335c9_iv -in secring.gpg.enc -out secring.gpg -d
-        - if [ -n "${TRAVIS_TAG}" ]; then ./gradlew publish closeAndReleaseRepository; else ./gradlew publish; fi
+        - ./gradlew publish closeAndReleaseRepository

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,9 +153,18 @@ subprojects {
     configure<SigningExtension> {
         isRequired = signingPassword != null && file(secretKeyRingFile).exists()
 
+        // TODO: Is it possible to access publishing extension in a safer way?
         val publishing: PublishingExtension by project.extensions
         sign(publishing.publications)
     }
+}
+
+tasks.closeRepository.configure {
+    onlyIf { !project.version.toString().endsWith("-SNAPSHOT") }
+}
+
+tasks.releaseRepository.configure {
+    onlyIf { !project.version.toString().endsWith("-SNAPSHOT") }
 }
 
 nexusStaging {


### PR DESCRIPTION
Because it isn't trivial to differentiate snapshot/release from Travis script.

See https://github.com/marcphilipp/nexus-publish-plugin/issues/33#issuecomment-493662583