### PR TITLE
Upgrade Gradle plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,9 +15,9 @@ tasks.wrapper {
 }
 
 plugins {
-    id("com.github.ben-manes.versions") version "0.25.0"
-    id("de.marcphilipp.nexus-publish") version "0.3.1" apply false
-    id("io.codearte.nexus-staging") version "0.21.1"
+    id("com.github.ben-manes.versions") version "0.27.0"
+    id("de.marcphilipp.nexus-publish") version "0.4.0" apply false
+    id("io.codearte.nexus-staging") version "0.21.2"
     idea
 }
 
@@ -102,6 +102,7 @@ subprojects {
 
     configure<NexusPublishExtension> {
         // We're constantly getting socket timeouts on Travis
+        connectTimeout.set(Duration.ofMinutes(3))
         clientTimeout.set(Duration.ofMinutes(3))
 
         repositories {


### PR DESCRIPTION
The new version of de.marcphilipp.nexus-publish supports to configure `connectTimeout`.
See https://github.com/marcphilipp/nexus-publish-plugin/pull/44.

The new version of io.codearte.nexus-staging contains a fix/workaround for Gradle 6.
See https://github.com/Codearte/gradle-nexus-staging-plugin/pull/142.

I cannot test if this already resolves the publishing issue with Gradle 6.