### PR TITLE
handle "Transfer-Encoding: chunked" header properly when LFS server asks us to send it

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,6 +38,11 @@ See link:gitlfs-server/src/test/java/ru/bozaro/gitlfs/server/ServerTest.java[] f
 
 == Changelog
 
+=== 0.17.0
+
+* Properly handle `Transfer-Encoding: chunked`.
+See https://github.com/bozaro/git-as-svn/issues/365[bozaro/git-as-svn#365]
+
 === 0.16.0
 
 * Update dependencies

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/Client.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/Client.java
@@ -28,8 +28,8 @@ import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static ru.bozaro.gitlfs.common.Constants.*;
 
@@ -110,9 +110,8 @@ public class Client implements Closeable {
     int redirectCount = 0;
     int retryCount = 0;
     while (true) {
-      final HttpUriRequest request = task.createRequest(mapper, url.toString());
-      addHeaders(request, link);
-
+      final LfsRequest lfsRequest = task.createRequest(mapper, url.toString());
+      final HttpUriRequest request = lfsRequest.addHeaders(link == null ? Collections.emptyMap() : link.getHeader());
       final CloseableHttpResponse response = http.executeMethod(request);
       boolean needClose = true;
       try {
@@ -157,14 +156,6 @@ public class Client implements Closeable {
       } finally {
         if (needClose)
           response.close();
-      }
-    }
-  }
-
-  protected void addHeaders(@Nonnull HttpUriRequest req, @CheckForNull Link link) {
-    if (link != null) {
-      for (Map.Entry<String, String> entry : link.getHeader().entrySet()) {
-        req.setHeader(entry.getKey(), entry.getValue());
       }
     }
   }

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/JsonPost.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/JsonPost.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ByteArrayEntity;
 
 import javax.annotation.Nonnull;
@@ -31,13 +30,13 @@ public class JsonPost<Req, Res> implements Request<Res> {
 
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
     final HttpPost method = new HttpPost(url);
     method.addHeader(HEADER_ACCEPT, MIME_LFS_JSON);
     final ByteArrayEntity entity = new ByteArrayEntity(mapper.writeValueAsBytes(req));
     entity.setContentType(MIME_LFS_JSON);
     method.setEntity(entity);
-    return method;
+    return new LfsRequest(method, entity);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LfsRequest.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LfsRequest.java
@@ -1,0 +1,44 @@
+package ru.bozaro.gitlfs.client.internal;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.protocol.HTTP;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public final class LfsRequest {
+  @Nonnull
+  private final HttpUriRequest request;
+  @Nullable
+  private final AbstractHttpEntity entity;
+
+  LfsRequest(@Nonnull HttpUriRequest request, @Nullable AbstractHttpEntity entity) {
+    this.request = request;
+    this.entity = entity;
+  }
+
+  @Nonnull
+  public HttpUriRequest addHeaders(@Nonnull Map<String, String> headers) {
+    for (Map.Entry<String, String> en : headers.entrySet()) {
+      if (HTTP.TRANSFER_ENCODING.equals(en.getKey())) {
+        /*
+          See https://github.com/bozaro/git-as-svn/issues/365
+          LFS-server can ask us to respond with chunked body via setting "Transfer-Encoding: chunked" HTTP header in LFS link
+          Unfortunately, we cannot pass it as-is to response HTTP headers, see RequestContent#process.
+          If it sees that Transfer-Encoding header was set, it throws exception immediately.
+          So instead, we suppress addition of Transfer-Encoding header and set entity to be chunked here.
+          RequestContent#process will see that HttpEntity#isChunked returns true and will set correct Transfer-Encoding header.
+        */
+        if (entity != null) {
+          final boolean chunked = HTTP.CHUNK_CODING.equals(en.getValue());
+          entity.setChunked(chunked);
+        }
+      } else {
+        request.addHeader(en.getKey(), en.getValue());
+      }
+    }
+    return request;
+  }
+}

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LockCreate.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LockCreate.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import ru.bozaro.gitlfs.common.data.*;
@@ -30,16 +29,15 @@ public final class LockCreate implements Request<LockCreate.Res> {
 
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
     final HttpPost req = new HttpPost(url);
     req.addHeader(HEADER_ACCEPT, MIME_LFS_JSON);
 
     final CreateLockReq createLockReq = new CreateLockReq(path, ref);
     final AbstractHttpEntity entity = new ByteArrayEntity(mapper.writeValueAsBytes(createLockReq));
     entity.setContentType(MIME_LFS_JSON);
-
     req.setEntity(entity);
-    return req;
+    return new LfsRequest(req, entity);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LockDelete.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LockDelete.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import ru.bozaro.gitlfs.common.data.DeleteLockReq;
@@ -31,8 +30,7 @@ public final class LockDelete implements Request<Lock> {
   }
 
   @Nonnull
-  @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
     final HttpPost req = new HttpPost(url);
     req.addHeader(HEADER_ACCEPT, MIME_LFS_JSON);
 
@@ -41,7 +39,7 @@ public final class LockDelete implements Request<Lock> {
     entity.setContentType(MIME_LFS_JSON);
 
     req.setEntity(entity);
-    return req;
+    return new LfsRequest(req, entity);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LocksList.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/LocksList.java
@@ -3,7 +3,6 @@ package ru.bozaro.gitlfs.client.internal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
 import ru.bozaro.gitlfs.common.data.LocksRes;
 
 import javax.annotation.Nonnull;
@@ -15,10 +14,10 @@ import static ru.bozaro.gitlfs.common.Constants.MIME_LFS_JSON;
 public final class LocksList implements Request<LocksRes> {
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) {
     final HttpGet req = new HttpGet(url);
     req.addHeader(HEADER_ACCEPT, MIME_LFS_JSON);
-    return req;
+    return new LfsRequest(req, null);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/MetaGet.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/MetaGet.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
 import ru.bozaro.gitlfs.common.data.ObjectRes;
 
 import javax.annotation.Nonnull;
@@ -21,10 +20,10 @@ import static ru.bozaro.gitlfs.common.Constants.MIME_LFS_JSON;
 public class MetaGet implements Request<ObjectRes> {
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) {
     final HttpGet req = new HttpGet(url);
     req.addHeader(HEADER_ACCEPT, MIME_LFS_JSON);
-    return req;
+    return new LfsRequest(req, null);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/MetaPost.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/MetaPost.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import ru.bozaro.gitlfs.common.data.Meta;
@@ -32,13 +31,13 @@ public class MetaPost implements Request<ObjectRes> {
 
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws JsonProcessingException {
     final HttpPost req = new HttpPost(url);
     req.addHeader(HEADER_ACCEPT, MIME_LFS_JSON);
     final AbstractHttpEntity entity = new ByteArrayEntity(mapper.writeValueAsBytes(meta));
     entity.setContentType(MIME_LFS_JSON);
     req.setEntity(entity);
-    return req;
+    return new LfsRequest(req, entity);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/ObjectGet.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/ObjectGet.java
@@ -3,7 +3,6 @@ package ru.bozaro.gitlfs.client.internal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
 import ru.bozaro.gitlfs.client.io.StreamHandler;
 
 import javax.annotation.Nonnull;
@@ -24,8 +23,9 @@ public class ObjectGet<T> implements Request<T> {
 
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) {
-    return new HttpGet(url);
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) {
+    final HttpGet req = new HttpGet(url);
+    return new LfsRequest(req, null);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/ObjectPut.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/ObjectPut.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.InputStreamEntity;
 import ru.bozaro.gitlfs.client.io.StreamProvider;
@@ -30,12 +29,12 @@ public class ObjectPut implements Request<Void> {
 
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws IOException {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws IOException {
     final HttpPut req = new HttpPut(url);
     final AbstractHttpEntity entity = new InputStreamEntity(streamProvider.getStream(), size);
     entity.setContentType(MIME_BINARY);
     req.setEntity(entity);
-    return req;
+    return new LfsRequest(req, entity);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/ObjectVerify.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/ObjectVerify.java
@@ -3,7 +3,6 @@ package ru.bozaro.gitlfs.client.internal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import ru.bozaro.gitlfs.common.data.Meta;
@@ -29,14 +28,14 @@ public class ObjectVerify implements Request<Void> {
 
   @Nonnull
   @Override
-  public HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws IOException {
+  public LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws IOException {
     final HttpPost req = new HttpPost(url);
     req.addHeader(HEADER_ACCEPT, MIME_LFS_JSON);
     final byte[] content = mapper.writeValueAsBytes(meta);
     final AbstractHttpEntity entity = new ByteArrayEntity(content);
     entity.setContentType(MIME_LFS_JSON);
     req.setEntity(entity);
-    return req;
+    return new LfsRequest(req, entity);
   }
 
   @Override

--- a/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/Request.java
+++ b/gitlfs-client/src/main/java/ru/bozaro/gitlfs/client/internal/Request.java
@@ -3,7 +3,6 @@ package ru.bozaro.gitlfs.client.internal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.HttpUriRequest;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -14,8 +13,9 @@ import java.io.IOException;
  * @author Artem V. Navrotskiy
  */
 public interface Request<R> {
+
   @Nonnull
-  HttpUriRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws IOException;
+  LfsRequest createRequest(@Nonnull ObjectMapper mapper, @Nonnull String url) throws IOException;
 
   R processResponse(@Nonnull ObjectMapper mapper, @Nonnull HttpResponse response) throws IOException;
 

--- a/gitlfs-client/src/test/java/ru/bozaro/gitlfs/client/ClientBatchTest.java
+++ b/gitlfs-client/src/test/java/ru/bozaro/gitlfs/client/ClientBatchTest.java
@@ -23,7 +23,7 @@ public class ClientBatchTest {
    */
   @Test
   public void batchUpload01() throws IOException {
-    batchUpload("/ru/bozaro/gitlfs/client/batch-upload-01.yml");
+    batchUpload("/ru/bozaro/gitlfs/client/batch-upload-01.yml", false);
   }
 
   /**
@@ -31,12 +31,17 @@ public class ClientBatchTest {
    */
   @Test
   public void batchUpload02() throws IOException {
-    batchUpload("/ru/bozaro/gitlfs/client/batch-upload-02.yml");
+    batchUpload("/ru/bozaro/gitlfs/client/batch-upload-02.yml", false);
   }
 
-  private void batchUpload(@Nonnull String path) throws IOException {
+  @Test
+  public void batchUploadChunked() throws IOException {
+    batchUpload("/ru/bozaro/gitlfs/client/batch-upload-chunked.yml", true);
+  }
+
+  private void batchUpload(@Nonnull String path, boolean chunked) throws IOException {
     final HttpReplay replay = YamlHelper.createReplay(path);
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(chunked), replay);
     final BatchRes result = client.postBatch(new BatchReq(
         Operation.Upload,
         Arrays.asList(
@@ -86,17 +91,9 @@ public class ClientBatchTest {
     batchDownload("/ru/bozaro/gitlfs/client/batch-download-01.yml");
   }
 
-  /**
-   * Simple download (JFrog Artifactory).
-   */
-  @Test
-  public void batchDownload02() throws IOException {
-    batchDownload("/ru/bozaro/gitlfs/client/batch-download-02.yml");
-  }
-
   private void batchDownload(@Nonnull String path) throws IOException {
     final HttpReplay replay = YamlHelper.createReplay(path);
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
     final BatchRes result = client.postBatch(new BatchReq(
         Operation.Download,
         Arrays.asList(
@@ -127,5 +124,13 @@ public class ClientBatchTest {
         )
     )));
     replay.close();
+  }
+
+  /**
+   * Simple download (JFrog Artifactory).
+   */
+  @Test
+  public void batchDownload02() throws IOException {
+    batchDownload("/ru/bozaro/gitlfs/client/batch-download-02.yml");
   }
 }

--- a/gitlfs-client/src/test/java/ru/bozaro/gitlfs/client/ClientLegacyTest.java
+++ b/gitlfs-client/src/test/java/ru/bozaro/gitlfs/client/ClientLegacyTest.java
@@ -22,7 +22,7 @@ public class ClientLegacyTest {
   @Test
   public void legacyUpload01() throws IOException {
     final HttpReplay replay = YamlHelper.createReplay("/ru/bozaro/gitlfs/client/legacy-upload-01.yml");
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
     Assert.assertTrue(client.putObject(new StringStreamProvider("Fri Oct 02 21:07:33 MSK 2015")));
     replay.close();
   }
@@ -33,7 +33,7 @@ public class ClientLegacyTest {
   @Test(expectedExceptions = ForbiddenException.class)
   public void legacyUpload02() throws IOException {
     final HttpReplay replay = YamlHelper.createReplay("/ru/bozaro/gitlfs/client/legacy-upload-02.yml");
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
     Assert.assertFalse(client.putObject(new StringStreamProvider("Fri Oct 02 21:07:33 MSK 2015")));
     replay.close();
   }
@@ -44,7 +44,7 @@ public class ClientLegacyTest {
   @Test
   public void legacyUpload03() throws IOException {
     final HttpReplay replay = YamlHelper.createReplay("/ru/bozaro/gitlfs/client/legacy-upload-03.yml");
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
     Assert.assertTrue(client.putObject(new StringStreamProvider("Fri Oct 02 21:07:33 MSK 2015")));
     replay.close();
   }
@@ -55,7 +55,7 @@ public class ClientLegacyTest {
   @Test
   public void legacyUpload04() throws IOException {
     final HttpReplay replay = YamlHelper.createReplay("/ru/bozaro/gitlfs/client/legacy-upload-04.yml");
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
     Assert.assertFalse(client.putObject(new StringStreamProvider("Hello, world!!!")));
     replay.close();
   }
@@ -66,7 +66,7 @@ public class ClientLegacyTest {
   @Test
   public void legacyDownload01() throws IOException {
     final HttpReplay replay = YamlHelper.createReplay("/ru/bozaro/gitlfs/client/legacy-download-01.yml");
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
     final byte[] data = client.getObject("b810bbe954d51e380f395de0c301a0a42d16f115453f2feb4188ca9f7189074e", ByteStreams::toByteArray);
     Assert.assertEquals(new String(data, StandardCharsets.UTF_8), "Fri Oct 02 21:07:33 MSK 2015");
     replay.close();
@@ -78,7 +78,7 @@ public class ClientLegacyTest {
   @Test
   public void legacyDownload02() throws IOException {
     final HttpReplay replay = YamlHelper.createReplay("/ru/bozaro/gitlfs/client/legacy-download-02.yml");
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
     try {
       client.getObject("01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b", ByteStreams::toByteArray);
       Assert.fail();

--- a/gitlfs-client/src/test/java/ru/bozaro/gitlfs/client/ClientLocksTest.java
+++ b/gitlfs-client/src/test/java/ru/bozaro/gitlfs/client/ClientLocksTest.java
@@ -17,7 +17,7 @@ public final class ClientLocksTest {
     final Ref ref = Ref.create("refs/heads/master");
 
     final HttpReplay replay = YamlHelper.createReplay("/ru/bozaro/gitlfs/client/locking-01.yml");
-    final Client client = new Client(new FakeAuthProvider(), replay);
+    final Client client = new Client(new FakeAuthProvider(false), replay);
 
     final Lock lock = client.lock("build.gradle", ref);
     Assert.assertNotNull(lock);

--- a/gitlfs-client/src/test/resources/ru/bozaro/gitlfs/client/batch-upload-chunked.yml
+++ b/gitlfs-client/src/test/resources/ru/bozaro/gitlfs/client/batch-upload-chunked.yml
@@ -1,0 +1,47 @@
+!!ru.bozaro.gitlfs.client.HttpRecord
+request:
+  body: !text |-
+    {
+      "operation" : "upload",
+      "objects" : [ {
+        "oid" : "b810bbe954d51e380f395de0c301a0a42d16f115453f2feb4188ca9f7189074e",
+        "size" : 28
+      }, {
+        "oid" : "1cbec737f863e4922cee63cc2ebbfaafcd1cff8b790d8cfd2e6a5d550b648afa",
+        "size" : 3
+      } ]
+    }
+  headers:
+    Accept: application/vnd.git-lfs+json
+    Authorization: RemoteAuth Token-1
+    Content-Type: application/vnd.git-lfs+json
+    Transfer-Encoding: chunked
+  href: http://gitlfs.local/test.git/info/lfs/objects/batch
+  method: POST
+response:
+  body: !text |-
+    {"objects":[{"oid":"b810bbe954d51e380f395de0c301a0a42d16f115453f2feb4188ca9f7189074e","size":28},{"oid":"1cbec737f863e4922cee63cc2ebbfaafcd1cff8b790d8cfd2e6a5d550b648afa","size":3,"actions":{"upload":{"href":"https://github-cloud.s3.amazonaws.com/alambic/media/111975537/1c/be/1cbec737f863e4922cee63cc2ebbfaafcd1cff8b790d8cfd2e6a5d550b648afa?actor_id=2458138","header":{"Authorization":"AWS4-HMAC-SHA256 Credential=Token-2","x-amz-content-sha256":"1cbec737f863e4922cee63cc2ebbfaafcd1cff8b790d8cfd2e6a5d550b648afa","x-amz-date":"20151007T190730Z"}},"verify":{"href":"https://api.github.com/lfs/bozaro/test/objects/1cbec737f863e4922cee63cc2ebbfaafcd1cff8b790d8cfd2e6a5d550b648afa/verify","header":{"Authorization":"RemoteAuth Token-3","Accept":"application/vnd.git-lfs+json"}}}}]}
+  headers:
+    Access-Control-Allow-Credentials: 'true'
+    Access-Control-Allow-Origin: '*'
+    Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+    Cache-Control: private, max-age=60, s-maxage=60
+    Content-Length: '989'
+    Content-Security-Policy: default-src 'none'
+    Content-Type: application/json; charset=utf-8
+    Date: Wed, 07 Oct 2015 19:07:30 GMT
+    ETag: '"4061c2b43579394fce28f86aaeef3502"'
+    Server: GitHub.com
+    Status: 200 OK
+    Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+    Vary: Accept-Encoding
+    X-Content-Type-Options: nosniff
+    X-Frame-Options: deny
+    X-GitHub-Media-Type: unknown
+    X-RateLimit-Limit: '3000'
+    X-RateLimit-Remaining: '2998'
+    X-RateLimit-Reset: '1444244860'
+    X-Served-By: a7f8a126c9ed3f1c4715a34c0ddc7290
+    X-XSS-Protection: 1; mode=block
+  statusCode: 200
+  statusText: OK


### PR DESCRIPTION
Before this commit, we would die when talking to GitLab >= 13.7:

    org.apache.http.client.ClientProtocolException
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:187)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
        at ru.bozaro.gitlfs.client.internal.HttpClientExecutor.executeMethod(HttpClientExecutor.java:27)
        at ru.bozaro.gitlfs.client.Client.doRequest(Client.java:117)
        at ru.bozaro.gitlfs.client.Client.putObject(Client.java:215)

        Caused by:
        org.apache.http.ProtocolException: Transfer-encoding header already present
            at org.apache.http.protocol.RequestContent.process(RequestContent.java:94)
            at org.apache.http.protocol.ImmutableHttpProcessor.process(ImmutableHttpProcessor.java:133)
            at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
            at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
            at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
            at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
            ... 9 more

This is caused by https://gitlab.com/gitlab-org/gitlab/-/merge_requests/48269.
Since that change, GitLab adds "Transfer-Encoding: chunked" HTTP header to LFS URL and we attempt to blindly add it to our response.

Unfortunately, org.apache.http.protocol.RequestContent.process doesn't like when someone except it sets
"Transfer-Encoding" HTTP header.

Thus, this commit adds custom handling for "Transfer-Encoding" HTTP header and delegates it to AbstractHttpEntity.setChunked

Fixes bozaro/git-as-svn#365